### PR TITLE
fix: kernel 6.16 support

### DIFF
--- a/include/osdep_service_linux.h
+++ b/include/osdep_service_linux.h
@@ -723,7 +723,14 @@ struct rtw_timer_list {
 	void *arg;
 };
 
-#if (LINUX_VERSION_CODE >= KERNEL_VERSION(4, 14, 0))
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(6, 16, 0))
+static inline void timer_hdl(struct timer_list *in_timer)
+{
+	_timer *ptimer = timer_container_of(ptimer, in_timer, timer);
+
+	ptimer->function(ptimer->arg);
+}
+#elif (LINUX_VERSION_CODE >= KERNEL_VERSION(4, 14, 0))
 static inline void timer_hdl(struct timer_list *in_timer)
 {
 	_timer *ptimer = from_timer(ptimer, in_timer, timer);


### PR DESCRIPTION
From what I understand, 'from_timer' was renamed 'timer_container_of' in kernel 6.16 which broke the build of the driver for me when I upgraded my system.
This quick fix seems to be working on my machine.